### PR TITLE
Resolve linting errors and create title component

### DIFF
--- a/main.tsx
+++ b/main.tsx
@@ -2,4 +2,5 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './src/App';
 
+// eslint-disable-next-line functional/no-expression-statement
 ReactDOM.render(<App />, document.getElementById('app'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,18 @@ import React from 'react';
 // Components
 import { Title } from './components/title';
 
-const App = (): JSX.Element => <Title />;
+// eslint-disable-next-line functional/functional-parameters
+const App = (): React.ReactElement => (
+  <>
+    <Title>
+      <div>A title</div>
+    </Title>
+
+    <Title>
+      <h2>A title with</h2>
+      <h2>more than one child!</h2>
+    </Title>
+  </>
+);
 
 export default App;

--- a/src/components/title.tsx
+++ b/src/components/title.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
+import React, { FunctionComponent } from 'react';
 
-const PureFunction = (wordOne: string, wordTwo: string): string => {
-  return `${wordOne} ${wordTwo}`;
+// For some reason this isn't working, any HTML element will pass this
+type HeadingElement = React.ReactElement<React.HTMLAttributes<HTMLHeadingElement>>;
+
+type Props = {
+  readonly children: HeadingElement | HeadingElement[];
 };
 
-export const Title = (PureFunction('Hello', 'World')) => {
+export const Title: FunctionComponent<Props> = (props: Props) => {
   return (
     <div>
-      <h1>{PureFunction}</h1>
+      {props.children}
     </div>
   );
 };


### PR DESCRIPTION
Doesn't really need merging I've just created the PR to show how I'd handle the title component, also had to resolve the linting errors.

For some reason `React.ReactElement<React.HTMLAttributes<HTMLHeadingElement>>` passes for any React element, it is supposed to only accept heading elements 🤷‍♂️ 